### PR TITLE
game selector template with working connection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -25,8 +29,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     testOptions{
@@ -81,4 +85,7 @@ dependencies {
     implementation libs.stomp
     implementation libs.reactivex
     implementation libs.rxandroid
+    implementation libs.retrofit
+    implementation libs.retrofit.jackson
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"
@@ -16,6 +16,10 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".ConnectToGameActivity"
+            android:exported="false"
+            android:screenOrientation="landscape"/>
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
@@ -24,6 +28,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".DemoActivity"
+            android:exported="false"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/group2/catan_android/ConnectToGameActivity.java
+++ b/app/src/main/java/com/group2/catan_android/ConnectToGameActivity.java
@@ -1,0 +1,179 @@
+package com.group2.catan_android;
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.activity.EdgeToEdge;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import com.group2.catan_android.adapter.GameListAdapter;
+import com.group2.catan_android.databinding.ActivityConnectToGameBinding;
+import com.group2.catan_android.networking.WebSocketClient;
+import com.group2.catan_android.networking.dto.ApiErrorResponse;
+import com.group2.catan_android.networking.dto.Game;
+import com.group2.catan_android.networking.dto.JoinGameRequest;
+import com.group2.catan_android.networking.dto.JoinGameResponse;
+import com.group2.catan_android.networking.dto.ListGameResponse;
+import com.group2.catan_android.networking.repository.GameRepository;
+import com.group2.catan_android.networking.socket.SocketManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.reactivex.functions.Consumer;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import ua.naiksoftware.stomp.dto.StompMessage;
+
+public class ConnectToGameActivity extends AppCompatActivity {
+
+    private Handler mainHandler;
+   private ActivityConnectToGameBinding binding;
+   private GameListAdapter adapter;
+   private final GameRepository repository = GameRepository.getInstance();
+   private final SocketManager socketManager = SocketManager.getInstance();
+   private final GameListAdapter.ItemClickListener listener = new GameListAdapter.ItemClickListener() {
+       @Override
+       public void onItemClicked(Game game) {
+           binding.selectedGame.gameID.setText(game.getGameID());
+           binding.selectedGame.playersConnected.setText(Integer.toString(game.getPlayerCount()));
+           selectedGame = game;
+       }
+   };
+
+   private Game selectedGame;
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        binding = ActivityConnectToGameBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            return insets;
+        });
+
+        getAvailableGames();
+        binding.refresh.setOnClickListener(v -> {
+            getAvailableGames();
+        });
+        binding.createNew.setOnClickListener(v -> {
+            joinGame(true);
+        });
+        binding.connect.setOnClickListener(v -> {
+            joinGame(false);
+        });
+
+        adapter = new GameListAdapter(this.listener);
+        binding.gamesRecyclerView.setAdapter(adapter);
+        mainHandler = new Handler(Looper.getMainLooper());
+    }
+
+    private void getAvailableGames() {
+        setLoading(true);
+        GameRepository repository = GameRepository.getInstance();
+        repository.listGames(new GameRepository.listCallback() {
+            @Override
+            public void onListReceived(ListGameResponse response) {
+                List<Game> games = response.getGameList();
+                if(games.isEmpty()) {
+                    showMessage("No games Found");
+                }else {
+                    adapter.setGames(games);
+                    binding.gamesRecyclerView.setVisibility(View.VISIBLE);
+                }
+                setLoading(false);
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                Log.d("Networking", "Failed to fetch games", throwable);
+                showMessage("Failed to fetch games");
+            }
+        });
+    }
+
+    private void showMessage(String message) {
+        binding.TextHint.setText(message);
+        binding.TextHint.setVisibility(View.VISIBLE);
+    }
+
+    private void setLoading(boolean isLoading) {
+        if(isLoading) {
+            binding.progressBar.setVisibility(View.VISIBLE);
+            binding.gamesRecyclerView.setVisibility(View.GONE);
+            binding.TextHint.setVisibility(View.GONE);
+        }else {
+            binding.progressBar.setVisibility(View.GONE);
+        }
+    }
+
+    private boolean checkInput(){
+        return !binding.playerName.getText().toString().isBlank();
+    }
+
+    private void joinGame(boolean create) {
+        if (!checkInput()) {
+            Toast.makeText(getApplicationContext(), "Name not set", Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        JoinGameRequest request = new JoinGameRequest();
+        request.setPlayerName(binding.playerName.getText().toString());
+        if(!create)
+            request.setGameID(selectedGame.getGameID());
+
+        GameRepository.JoinCallback callback = new GameRepository.JoinCallback() {
+            @Override
+            public void onJoin(JoinGameResponse joinGameResponse) {
+                Log.d("Game", "joined " + joinGameResponse.getGameID());
+                Log.d("Game", "token " + joinGameResponse.token);
+                Toast.makeText(ConnectToGameActivity.this, "Connected", Toast.LENGTH_SHORT).show();
+                socketManager.connect(joinGameResponse.token);
+                socketManager.onLifecycleEvent(lifecycleEvent -> {
+                    switch (lifecycleEvent.getType()) {
+                        case ERROR:
+                            Log.d("Socket", "error");
+                            break;
+                        case OPENED:
+                            Log.d("socket", "Opened");
+                            break;
+                        case CLOSED:
+                            Log.d("Socket", "closed");
+                    }
+                    socketManager.subscribe("/topic/game/" + joinGameResponse.getGameID() + "/messages", message -> {
+                        Log.d("Comm", message.getPayload().strip());
+                        mainHandler.post(() -> {
+                                    Toast.makeText(ConnectToGameActivity.this, message.getPayload().strip(), Toast.LENGTH_SHORT).show();
+                                }
+                            );
+                    });
+                });
+            }
+
+            @Override
+            public void onJoinUnsuccessful(ApiErrorResponse errorResponse) {
+                Log.d("Game", "did not join" + errorResponse.getMessage());
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                Log.d("Game", "error", throwable);
+            }
+        };
+        repository.join(request, callback, create);
+    }
+
+}

--- a/app/src/main/java/com/group2/catan_android/DemoActivity.java
+++ b/app/src/main/java/com/group2/catan_android/DemoActivity.java
@@ -1,0 +1,56 @@
+package com.group2.catan_android;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.activity.EdgeToEdge;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import com.group2.catan_android.networking.WebSocketClient;
+
+public class DemoActivity extends AppCompatActivity {
+
+    TextView textViewServerResponse;
+
+    WebSocketClient networkHandler;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        setContentView(R.layout.activity_demo);
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            return insets;
+        });
+
+        Button buttonConnect = findViewById(R.id.buttonConnect);
+        buttonConnect.setOnClickListener(v -> connectToWebSocketServer());
+
+        Button buttonSendMsg = findViewById(R.id.buttonSendMsg);
+        buttonSendMsg.setOnClickListener(v -> sendMessage());
+
+        textViewServerResponse = findViewById(R.id.textViewResponse);
+
+        networkHandler = new WebSocketClient();
+    }
+
+    private void connectToWebSocketServer() {
+        // register a handler for received messages when setting up the connection
+        networkHandler.connectToServer(this::messageReceivedFromServer);
+    }
+
+    private void sendMessage() {
+        networkHandler.sendMessageToServer("test message");
+    }
+
+    private void messageReceivedFromServer(String message) {
+        // TODO handle received messages
+        textViewServerResponse.setText(message);
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/MainActivity.java
+++ b/app/src/main/java/com/group2/catan_android/MainActivity.java
@@ -1,9 +1,8 @@
 package com.group2.catan_android;
 
+import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.Button;
-import android.widget.TextView;
 
 import androidx.activity.EdgeToEdge;
 import androidx.appcompat.app.AppCompatActivity;
@@ -11,18 +10,13 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
-import com.group2.catan_android.networking.WebSocketClient;
-
 public class MainActivity extends AppCompatActivity {
-
-    TextView textViewServerResponse;
-
-    WebSocketClient networkHandler;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
+
         setContentView(R.layout.activity_main);
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
@@ -30,28 +24,15 @@ public class MainActivity extends AppCompatActivity {
             return insets;
         });
 
-        Button buttonConnect = findViewById(R.id.buttonConnect);
-        buttonConnect.setOnClickListener(v -> connectToWebSocketServer());
+        Button demo = findViewById(R.id.btnDemo);
+        demo.setOnClickListener(v -> navigate(DemoActivity.class));
 
-        Button buttonSendMsg = findViewById(R.id.buttonSendMsg);
-        buttonSendMsg.setOnClickListener(v -> sendMessage());
-
-        textViewServerResponse = findViewById(R.id.textViewResponse);
-
-        networkHandler = new WebSocketClient();
+        Button connection = findViewById(R.id.btnConnection);
+        connection.setOnClickListener(v -> navigate(ConnectToGameActivity.class));
     }
 
-    private void connectToWebSocketServer() {
-        // register a handler for received messages when setting up the connection
-        networkHandler.connectToServer(this::messageReceivedFromServer);
-    }
-
-    private void sendMessage() {
-        networkHandler.sendMessageToServer("test message");
-    }
-
-    private void messageReceivedFromServer(String message) {
-        // TODO handle received messages
-        textViewServerResponse.setText(message);
+    private void navigate(Class<?> cl){
+        Intent i = new Intent(getApplicationContext(), cl);
+        startActivity(i);
     }
 }

--- a/app/src/main/java/com/group2/catan_android/adapter/GameListAdapter.java
+++ b/app/src/main/java/com/group2/catan_android/adapter/GameListAdapter.java
@@ -1,0 +1,82 @@
+package com.group2.catan_android.adapter;
+
+import android.content.ClipData;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.group2.catan_android.databinding.GameItemBinding;
+import com.group2.catan_android.networking.dto.Game;
+
+import java.util.List;
+
+public class GameListAdapter extends RecyclerView.Adapter<GameListAdapter.GameListViewHolder> {
+
+    private List<Game> games;
+    private final ItemClickListener listener;
+
+    public GameListAdapter(List<Game> games, ItemClickListener listener){
+        this.games = games;
+        this.listener = listener;
+    }
+
+    public GameListAdapter(ItemClickListener listener){
+        this.games = List.of();
+        this.listener = listener;
+    }
+
+    public void setGames(List<Game> games){
+        this.games = games;
+        notifyDataSetChanged();
+    }
+
+
+    @NonNull
+    @Override
+    public GameListViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        GameItemBinding itemBinding = GameItemBinding.inflate(
+                LayoutInflater.from(parent.getContext()),
+                parent,
+                false
+        );
+        return new GameListViewHolder(itemBinding);
+    }
+
+
+    @Override
+    public void onBindViewHolder(@NonNull GameListViewHolder holder, int position) {
+        holder.setGameData(games.get(position));
+        holder.bindListener(games.get(position), listener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return games.size();
+    }
+
+    public static class GameListViewHolder extends RecyclerView.ViewHolder{
+
+        GameItemBinding binding;
+        GameListViewHolder(GameItemBinding gameItemBinding){
+            super(gameItemBinding.getRoot());
+            binding = gameItemBinding;
+        }
+
+        void bindListener(Game game, ItemClickListener listener){
+            binding.getRoot().setOnClickListener(v ->
+                    listener.onItemClicked(game)
+            );
+        }
+
+        void setGameData(Game game){
+            binding.gameID.setText(game.getGameID());
+            binding.playersConnected.setText(Integer.toString(game.getPlayerCount()));
+        }
+    }
+
+    public interface ItemClickListener{
+        void onItemClicked(Game game);
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/networking/api/GameApiClient.java
+++ b/app/src/main/java/com/group2/catan_android/networking/api/GameApiClient.java
@@ -1,0 +1,21 @@
+package com.group2.catan_android.networking.api;
+
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+public class GameApiClient {
+    private static final String BASE_URL = "http://10.0.2.2:8080/catan/game/";
+    private static GameApiService gameApiService;
+    private static final Retrofit retrofit = new Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build();
+    private GameApiClient(){}
+
+    public static GameApiService getGameApiService(){
+        if(gameApiService == null){
+            gameApiService = retrofit.create(GameApiService.class);
+        }
+        return gameApiService;
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/networking/api/GameApiService.java
+++ b/app/src/main/java/com/group2/catan_android/networking/api/GameApiService.java
@@ -1,0 +1,25 @@
+package com.group2.catan_android.networking.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.group2.catan_android.networking.dto.JoinGameRequest;
+import com.group2.catan_android.networking.dto.JoinGameResponse;
+import com.group2.catan_android.networking.dto.ListGameResponse;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+public interface GameApiService {
+    @POST("create")
+    Call<JoinGameResponse> createAndJoin(@Body JoinGameRequest request);
+
+    @POST("connect")
+    Call<JoinGameResponse> join(@Body JoinGameRequest request);
+
+    @GET("list")
+    Call<ListGameResponse> list();
+
+}

--- a/app/src/main/java/com/group2/catan_android/networking/dto/ApiErrorResponse.java
+++ b/app/src/main/java/com/group2/catan_android/networking/dto/ApiErrorResponse.java
@@ -1,0 +1,22 @@
+package com.group2.catan_android.networking.dto;
+
+public class ApiErrorResponse {
+    private int statusCode;
+    private String message;
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/networking/dto/Game.java
+++ b/app/src/main/java/com/group2/catan_android/networking/dto/Game.java
@@ -1,0 +1,26 @@
+package com.group2.catan_android.networking.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Game {
+    @JsonProperty("gameID")
+    private String gameID;
+    @JsonProperty("playerCount")
+    private int playerCount;
+
+    public String getGameID() {
+        return gameID;
+    }
+
+    public void setGameID(String gameID) {
+        this.gameID = gameID;
+    }
+
+    public int getPlayerCount() {
+        return playerCount;
+    }
+
+    public void setPlayerCount(int playerCount) {
+        this.playerCount = playerCount;
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/networking/dto/JoinGameRequest.java
+++ b/app/src/main/java/com/group2/catan_android/networking/dto/JoinGameRequest.java
@@ -1,0 +1,28 @@
+package com.group2.catan_android.networking.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JoinGameRequest {
+    private String playerName;
+    private String gameID;
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public void setPlayerName(String playerName) {
+        this.playerName = playerName;
+    }
+
+    public String getGameID() {
+        return gameID;
+    }
+
+    public void setGameID(String gameID) {
+        this.gameID = gameID;
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/networking/dto/JoinGameResponse.java
+++ b/app/src/main/java/com/group2/catan_android/networking/dto/JoinGameResponse.java
@@ -1,0 +1,38 @@
+package com.group2.catan_android.networking.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JoinGameResponse {
+    @JsonProperty("playerName")
+    public String playerName;
+    @JsonProperty("gameID")
+    public String gameID;
+    @JsonProperty("token")
+    public String token;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public void setPlayerName(String playerName) {
+        this.playerName = playerName;
+    }
+
+    public String getGameID() {
+        return gameID;
+    }
+
+    public void setGameID(String gameID) {
+        this.gameID = gameID;
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/networking/dto/ListGameResponse.java
+++ b/app/src/main/java/com/group2/catan_android/networking/dto/ListGameResponse.java
@@ -1,0 +1,28 @@
+package com.group2.catan_android.networking.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class ListGameResponse {
+    @JsonProperty("count")
+    private int count;
+    @JsonProperty("gameList")
+    List<Game> gameList;
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public List<Game> getGameList() {
+        return gameList;
+    }
+
+    public void setGameList(List<Game> gameList) {
+        this.gameList = gameList;
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/networking/repository/GameRepository.java
+++ b/app/src/main/java/com/group2/catan_android/networking/repository/GameRepository.java
@@ -1,0 +1,93 @@
+package com.group2.catan_android.networking.repository;
+
+import android.util.Log;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group2.catan_android.networking.api.GameApiClient;
+import com.group2.catan_android.networking.api.GameApiService;
+import com.group2.catan_android.networking.dto.ApiErrorResponse;
+import com.group2.catan_android.networking.dto.Game;
+import com.group2.catan_android.networking.dto.JoinGameRequest;
+import com.group2.catan_android.networking.dto.JoinGameResponse;
+import com.group2.catan_android.networking.dto.ListGameResponse;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.internal.EverythingIsNonNull;
+
+public class GameRepository {
+    //Todo: back with datasource
+    private final GameApiService apiService;
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final GameRepository instance = new GameRepository();
+
+    private GameRepository(){
+        this.apiService = GameApiClient.getGameApiService();
+    }
+
+    public static GameRepository getInstance(){
+        return instance;
+    }
+
+    public void join(JoinGameRequest request, final JoinCallback callback, boolean create){
+        Call<JoinGameResponse> call = create ? apiService.createAndJoin(request)
+                : apiService.join(request);
+        Log.d("message", call.request().url().toString());
+        call.enqueue(new Callback<JoinGameResponse>() {
+            @Override
+            @EverythingIsNonNull
+            public void onResponse(Call<JoinGameResponse> call, Response<JoinGameResponse> response) {
+                if(response.isSuccessful()){
+                    JoinGameResponse successfulResponse = response.body();
+                    callback.onJoin(successfulResponse);
+                }else {
+                    try (okhttp3.ResponseBody errorResponse = response.errorBody()) {
+                        ApiErrorResponse apiError = mapper.readValue(errorResponse.string(), ApiErrorResponse.class);
+                        callback.onJoinUnsuccessful(apiError);
+                    }catch (Exception e){
+                        Log.e("Network", "cannot Process response", e);
+                    }
+
+                }
+            }
+
+            @Override
+            @EverythingIsNonNull
+            public void onFailure(Call<JoinGameResponse> call, Throwable throwable) {
+                callback.onError(throwable);
+            }
+        });
+    }
+
+    public void listGames(listCallback callback){
+        Call<ListGameResponse> call = apiService.list();
+        call.enqueue(new Callback<>() {
+            @Override
+            public void onResponse(Call<ListGameResponse> call, Response<ListGameResponse> response) {
+                if (response.isSuccessful()) {
+                    ListGameResponse successfulResponse = response.body();
+                    callback.onListReceived(successfulResponse);
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ListGameResponse> call, Throwable throwable) {
+                callback.onFailure(throwable);
+            }
+        });
+    }
+
+    public interface JoinCallback {
+        void onJoin(JoinGameResponse joinGameResponse);
+        void onJoinUnsuccessful(ApiErrorResponse errorResponse);
+        void onError(Throwable throwable);
+    }
+
+    public interface listCallback {
+        void onListReceived(ListGameResponse response);
+        void onFailure(Throwable throwable);
+    }
+}

--- a/app/src/main/java/com/group2/catan_android/networking/socket/SocketManager.java
+++ b/app/src/main/java/com/group2/catan_android/networking/socket/SocketManager.java
@@ -1,0 +1,73 @@
+package com.group2.catan_android.networking.socket;
+
+import android.hardware.ConsumerIrManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Consumer;
+import ua.naiksoftware.stomp.Stomp;
+import ua.naiksoftware.stomp.StompClient;
+import ua.naiksoftware.stomp.dto.LifecycleEvent;
+import ua.naiksoftware.stomp.dto.StompMessage;
+
+public class SocketManager {
+    private static final String SOCKET_URI = "ws://10.0.2.2:8080/catan";
+    private StompClient client;
+
+    private Disposable liveCycleSubscriptions;
+    private CompositeDisposable messageSubscriptions;
+
+    private static final SocketManager instance = new SocketManager();
+
+    public static SocketManager getInstance(){
+        return instance;
+    }
+
+    public SocketManager(){
+        messageSubscriptions = new CompositeDisposable();
+    };
+
+    public void reInit(){
+        disconnect();
+        messageSubscriptions = new CompositeDisposable();
+    }
+
+    public void connect(String token){
+        Map<String, String> auth = Map.of("Authorization", token);
+        client = Stomp.over(Stomp.ConnectionProvider.OKHTTP, SOCKET_URI, auth);
+        client.connect();
+    }
+
+    public void onLifecycleEvent(Consumer<LifecycleEvent> consumer){
+        if(liveCycleSubscriptions != null)
+            liveCycleSubscriptions.dispose();
+        liveCycleSubscriptions = client.lifecycle().subscribe(consumer);
+    }
+
+    public void disconnect(){
+        if(client != null)
+            client.disconnect();
+        messageSubscriptions.dispose();
+        messageSubscriptions.clear();
+        if(liveCycleSubscriptions != null)
+            liveCycleSubscriptions.dispose();
+    }
+
+    public void subscribe(String destination, Consumer<StompMessage> onMessage){
+        messageSubscriptions.add(client.topic(destination).subscribe(onMessage));
+    }
+    public void subscribe(String destination, Consumer<StompMessage> onMessage, Consumer<Throwable> onError){
+        messageSubscriptions.add(client.topic(destination).subscribe(onMessage, onError));
+    }
+
+    public boolean isConnected(){
+        return client.isConnected();
+    }
+
+
+
+}

--- a/app/src/main/java/com/group2/catan_android/networking/socket/SocketManager.java
+++ b/app/src/main/java/com/group2/catan_android/networking/socket/SocketManager.java
@@ -37,6 +37,9 @@ public class SocketManager {
     }
 
     public void connect(String token){
+        if(isConnected()){
+            disconnect();
+        }
         Map<String, String> auth = Map.of("Authorization", token);
         client = Stomp.over(Stomp.ConnectionProvider.OKHTTP, SOCKET_URI, auth);
         client.connect();
@@ -65,7 +68,9 @@ public class SocketManager {
     }
 
     public boolean isConnected(){
-        return client.isConnected();
+        if(client != null)
+            return client.isConnected();
+        return false;
     }
 
 

--- a/app/src/main/res/drawable/baseline_refresh.xml
+++ b/app/src/main/res/drawable/baseline_refresh.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_connect_to_game.xml
+++ b/app/src/main/res/layout/activity_connect_to_game.xml
@@ -53,7 +53,7 @@
                 android:layout_height="wrap_content"
                 android:text="Connect New"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/button"
+                app:layout_constraintEnd_toStartOf="@+id/connect"
                 app:layout_constraintHorizontal_chainStyle="spread"
                 app:layout_constraintStart_toStartOf="parent" />
 

--- a/app/src/main/res/layout/activity_connect_to_game.xml
+++ b/app/src/main/res/layout/activity_connect_to_game.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ConnectToGameActivity">
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        android:padding="12sp"
+        android:baselineAligned="false">
+
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/connect_to_game"
+                android:textAlignment="center"
+                android:textSize="20sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+            <include layout="@layout/game_item"
+                android:id="@+id/selectedGame"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/title"
+                android:layout_marginTop="20dp"/>
+
+            <EditText
+                android:id="@+id/playerName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="20dp"
+                app:layout_constraintBottom_toTopOf="@+id/createNew"
+                app:layout_constraintStart_toStartOf="parent"
+                android:hint="Player Name" />
+
+            <Button
+                android:id="@+id/createNew"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Connect New"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/button"
+                app:layout_constraintHorizontal_chainStyle="spread"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <Button
+                android:id="@+id/connect"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Connect Selected"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/createNew"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/gamesRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+            <ProgressBar
+                android:id="@+id/progressBar"
+                android:layout_width="50sp"
+                android:layout_height="50sp"
+                android:layout_gravity="center"/>
+            <TextView
+                android:id="@+id/TextHint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="feedback"
+                android:visibility="gone"
+                android:textAlignment="center"/>
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/refresh"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/baseline_refresh"
+                android:layout_gravity="end"
+                android:layout_marginTop="12sp"
+                android:layout_marginEnd="12sp" />
+
+        </FrameLayout>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_demo.xml
+++ b/app/src/main/res/layout/activity_demo.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DemoActivity">
+
+    <TextView
+        android:id="@+id/textView4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="WebSocketDemo"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large"
+        app:layout_constraintBottom_toTopOf="@+id/buttonConnect"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/buttonConnect"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Connect"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textViewResponse"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Response"
+        android:textAlignment="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonConnect" />
+
+    <Button
+        android:id="@+id/buttonSendMsg"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Send something"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonConnect" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,45 +7,41 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:id="@+id/textView4"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="WebSocketDemo"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large"
-        app:layout_constraintBottom_toTopOf="@+id/buttonConnect"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <Button
-        android:id="@+id/buttonConnect"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Connect"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/textViewResponse"
+    <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="Response"
-        android:textAlignment="center"
+        android:layout_height="0dp"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/buttonConnect" />
+        app:layout_constraintTop_toTopOf="parent">
 
-    <Button
-        android:id="@+id/buttonSendMsg"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="Send something"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/buttonConnect" />
+        <TextView
+            android:id="@+id/textView2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10px"
+            android:layout_marginBottom="10px"
+            android:text="Select Activity"
+            android:textAlignment="center"
+            android:textSize="20sp" />
+
+        <Button
+            android:id="@+id/btnDemo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="demoActivity" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <Button
+            android:id="@+id/btnConnection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="connectionActivity" />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/game_item.xml
+++ b/app/src/main/res/layout/game_item.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/gameIDLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="GameID:"
+        android:textSize="24sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+    <TextView
+        android:id="@+id/gameID"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="24sp"
+        android:text="none"
+        app:layout_constraintStart_toEndOf="@+id/gameIDLabel"
+        app:layout_constraintTop_toTopOf="@+id/gameIDLabel"
+        android:layout_marginStart="10dp"/>
+    <TextView
+        android:id="@+id/playersConnectedLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="PlayersConnected:"
+        app:layout_constraintTop_toBottomOf="@+id/gameIDLabel"
+        app:layout_constraintStart_toStartOf="parent"
+        android:textSize="16sp"/>
+    <TextView
+        android:id="@+id/playersConnected"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="unknown"
+        android:textSize="16sp"
+        app:layout_constraintStart_toEndOf="@id/playersConnectedLabel"
+        app:layout_constraintTop_toTopOf="@id/playersConnectedLabel"
+        android:layout_marginStart="5dp"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">catan_android</string>
+    <string name="connect_to_game">Connect to Game</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ okhttp = "4.10.0"
 stomp = "1.6.6"
 reactivex = "2.2.5"
 rxandroid =  "2.1.0"
+retrofit = "2.10.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -27,6 +28,8 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 stomp = { module = 'com.github.NaikSoftware:StompProtocolAndroid', version.ref = "stomp"}
 reactivex = { module = 'io.reactivex.rxjava2:rxjava', version.ref = "reactivex"}
 rxandroid = { module = 'io.reactivex.rxjava2:rxjava', version.ref = "rxandroid"}
+retrofit = {module = 'com.squareup.retrofit2:retrofit', version.ref = "retrofit"}
+retrofit_jackson = {module = 'com.squareup.retrofit2:converter-jackson', version.ref = "retrofit"}
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Changes: Main activity allows for switching between activities that work on their own, but not yet together.

Connection activity: This activity allows the user to browse for games, select one and connect to it. A new game can also be created. 

For demonstration purposes, a connection to the stomp broker is established with the obtained token. The user will see a Toast if a new player connects to the game where he is connected to. 

Currently there is no visual feedback that a user is indeed connected to a game despite a Toast that is shown once a connection has been established. Error handling needs to be improved.

The connected game (or its descriptors as well as the token) should be stored in a local datastore so that the user can reconnect to the game in case of connection loss.